### PR TITLE
Avoid using brackets in place of parentheses

### DIFF
--- a/ideque-2list/ideque-tests.scm
+++ b/ideque-2list/ideque-tests.scm
@@ -56,8 +56,8 @@
 
 (test-group "ideque/other-accessors"
  (define (check name ideque-op list-op n)
-   (let* ([lis (iota n)]
-          [dq (list->ideque lis)])
+   (let* ((lis (iota n))
+          (dq (list->ideque lis)))
      (for-each (lambda (i)
                  (test (cons name i)
                        (receive xs (list-op lis i) xs)

--- a/ideque-2list/run-tests.scm
+++ b/ideque-2list/run-tests.scm
@@ -1,5 +1,5 @@
 (cond-expand
- [gauche
+ (gauche
   (use gauche.test)
   (use compat.chibi-test)
   (use srfi-121)
@@ -9,6 +9,6 @@
   (test-module 'ideque)
   (chibi-test
    (include "ideque-tests.scm"))
-  (test-end)]
- [else
-  (display "Add implementation-specific test runner.\n")])
+  (test-end))
+ (else
+  (display "Add implementation-specific test runner.\n")))


### PR DESCRIPTION
To be R7RS compliant.
